### PR TITLE
NWBLZR-94 API: Purchase Order - update an item

### DIFF
--- a/Northwind.Core/Interfaces/Repositories/IPurchaseOrderItemsRepository.cs
+++ b/Northwind.Core/Interfaces/Repositories/IPurchaseOrderItemsRepository.cs
@@ -12,5 +12,6 @@ namespace Northwind.Core.Interfaces.Repositories
         Task Create(PurchaseOrderItem purchaseOrderItem);
         Task DeleteAsync(int purchaseOrderItemId);
         Task<PurchaseOrderItem?> GetAsync(int purchaseOrderItemId);
+        void Update(PurchaseOrderItem purchaseOrderItem);
     }
 }

--- a/Northwind.Core/Interfaces/Services/IPurchaseOrdersService.cs
+++ b/Northwind.Core/Interfaces/Services/IPurchaseOrdersService.cs
@@ -23,5 +23,6 @@ namespace Northwind.Core.Interfaces.Services
         Task RemoveItem(int purchaseOrderItemId);
         Task<ServiceMessageResult> SubmitAsync(int id);
         Task<ServiceResult> UpdateAsync(int id, PurchaseOrderDto purchaseOrderDto);
+        Task UpdateItem(int purchaseOrderId, PurchaseOrderItemDto purchaseOrderItem);
     }
 }

--- a/Northwind.Data.Postgresql/Repositories/PurchaseOrderItemsRepository.cs
+++ b/Northwind.Data.Postgresql/Repositories/PurchaseOrderItemsRepository.cs
@@ -33,5 +33,10 @@ namespace Northwind.Data.Postgresql.Repositories
         {
             return await _efDbContext.PurchaseOrderItems.FirstOrDefaultAsync(x => x.Id == purchaseOrderItemId);
         }
+
+        public void Update(PurchaseOrderItem purchaseOrderItem)
+        {
+            _efDbContext.PurchaseOrderItems.Update(purchaseOrderItem);
+        }
     }
 }


### PR DESCRIPTION
NWBLZR-94 API: Purchase Order - update an item.
As a sales coordinator
I should be able to update an item with the correct quantity and unit price
So that I can comply with the procurement requirements.

Conditions:
- PO must exist.
- Item must exist.
- Quantity must be > 0.
- UnitPrice must be > 0.