### PR TITLE
NWBLZR-119 API: Customer Order - cancel order

### DIFF
--- a/Northwind.Core/Interfaces/Services/ICustomerOrdersService.cs
+++ b/Northwind.Core/Interfaces/Services/ICustomerOrdersService.cs
@@ -19,5 +19,6 @@ namespace Northwind.Core.Interfaces.Services
         Task<CustomerOrderDto?> GetAsync(int orderId);
         Task UpdateItem(int customerOrderId, CustomerOrderItemDto customerOrderItem);
         Task RemoveItem(int customerOrderItemId);
+        Task<ServiceMessageResult> CancelAsync(int customerOrderId);
     }
 }


### PR DESCRIPTION
NWBLZR-119 API: Customer Order - cancel order
**Use Story**
As a sales coordinator
I should be able to cancel customer order
So that I can prevent fulfillment issues.

**Conditions**
- Customer order must exist.
- If status is New.

**Output**
- Status is Cancelled.