### PR TITLE
NWBLZR-120 API: Customer Order - mark order as invoiced

### DIFF
--- a/Northwind.Core/Interfaces/Services/ICustomerOrdersService.cs
+++ b/Northwind.Core/Interfaces/Services/ICustomerOrdersService.cs
@@ -20,5 +20,6 @@ namespace Northwind.Core.Interfaces.Services
         Task UpdateItem(int customerOrderId, CustomerOrderItemDto customerOrderItem);
         Task RemoveItem(int customerOrderItemId);
         Task<ServiceMessageResult> CancelAsync(int customerOrderId);
+        Task<ServiceMessageResult> MarkAsInvoiced(int customerOrderId);
     }
 }


### PR DESCRIPTION
NWBLZR-120 API: Customer Order - mark order as invoiced
**User Story**
As a sales coordinator
I should be able to able to mark an order as invoiced
So that I can comply with the fulfillment requirements.

Conditions:
- Order must exist.
- Status is New.
- Due date has been set.
- Shipping information must be set.

Output:
- Order status is set to Invoiced.