### PR TITLE
NWBLZR-121 API: Customer Order - mark order as shipped

### DIFF
--- a/Northwind.Core/Interfaces/Services/ICustomerOrdersService.cs
+++ b/Northwind.Core/Interfaces/Services/ICustomerOrdersService.cs
@@ -21,5 +21,6 @@ namespace Northwind.Core.Interfaces.Services
         Task RemoveItem(int customerOrderItemId);
         Task<ServiceMessageResult> CancelAsync(int customerOrderId);
         Task<ServiceMessageResult> MarkAsInvoiced(int customerOrderId);
+        Task MarkAsShipped(int customerOrderId);
     }
 }


### PR DESCRIPTION
NWBLZR-121 API: Customer Order - mark order as shipped

**User Story**
As a sales coordinator
I should be able to marked an order as Shipped
So that I can monitor the order during the fulfillment process.

**Conditions:**
- Order must exist.
- Status is Invoiced.

**Output:**
- Status set to Shipped.