### PR TITLE
NWBLZR-122 API: Customer Order - mark order as paid

### DIFF
--- a/Northwind.Core/Interfaces/Services/ICustomerOrdersService.cs
+++ b/Northwind.Core/Interfaces/Services/ICustomerOrdersService.cs
@@ -22,5 +22,6 @@ namespace Northwind.Core.Interfaces.Services
         Task<ServiceMessageResult> CancelAsync(int customerOrderId);
         Task<ServiceMessageResult> MarkAsInvoiced(int customerOrderId);
         Task MarkAsShipped(int customerOrderId);
+        Task<ServiceMessageResult> MarkAsPaid(int customerOrderId);
     }
 }


### PR DESCRIPTION
NWBLZR-122 API: Customer Order - mark order as paid

**User Story**
As a sales coordinator
I should be able to mark an order as Paid
So that I can make sure that the order is paid on schedule.

**Conditions:**
- Order must exist.
- Status is Invoiced.

**Output:**
- Status set to Paid.